### PR TITLE
Fixed issue with url generation and minor refactor

### DIFF
--- a/src/LIN3S/CMSKernel/Infrastructure/Symfony/Form/Type/FileType.php
+++ b/src/LIN3S/CMSKernel/Infrastructure/Symfony/Form/Type/FileType.php
@@ -67,7 +67,7 @@ class FileType extends AbstractType
                 new FileOfIdQuery($fileId)
             );
 
-            $filePreview = $this->appendFilePreviewPath($filePreview);
+            $filePreview['preview_path'] = $this->getFilePreviewPath($filePreview['file_name'], $options);
         }
 
         $view->vars = array_merge(
@@ -175,15 +175,13 @@ class FileType extends AbstractType
         }, $queryHandlers);
     }
 
-    private function appendFilePreviewPath($filePreview)
+    private function getFilePreviewPath($filename, array $options)
     {
-        $filePreview['preview_path'] = $this->urlGenerator->generate(
-            'bengor_file_' . $this->implicitFileType . '_download',
+        return $this->urlGenerator->generate(
+            'bengor_file_' . $this->fileType($options) . '_download',
             [
-                'filename' => $filePreview['file_name'],
+                'filename' => $filename,
             ]
         );
-
-        return $filePreview;
     }
 }


### PR DESCRIPTION
Route generation was always using implicit file type instead of checking entry_file passed in options. Refactored appendFilePreviewPath to getFilePreviewPath, avoiding received parameter modification and extracting assignment to parent class.